### PR TITLE
Feature#4 Menu Drawer 구현

### DIFF
--- a/src/components/home/Menu/index.tsx
+++ b/src/components/home/Menu/index.tsx
@@ -1,136 +1,154 @@
 import {
-    Menu as CustomedMenu,
-    MenuButton,
-    MenuList,
-    MenuItem,
-    Flex,
-    Box,
-    Image
-  } from "@chakra-ui/react";
-  import { Link } from "react-router-dom";
-  import { IconButton } from "@chakra-ui/icons";
-  import { Settings, Github, Search, Fish, MenuIcon, Dice5, LogOut} from "lucide-react";
-  import profile_example from "../../../assets/profile_example.jpg";
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  Flex,
+  Box,
+  Image,
+  Button,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { Link } from "react-router-dom";
+import { Settings, Github, Search, Fish, Dice5, LogOut, MenuIcon } from "lucide-react";
+import profile_example from "../../../assets/profile_example.jpg";
 
-  export const Menu = () => {
-    const nickName = "자고싶어핑";
-    return (
-      <Flex width="100%" justifyContent="flex-end" p={0}>
-        <CustomedMenu >
+export const DrawerMenu = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const nickName = "자고싶어핑";
 
-          <MenuButton
-            as={IconButton}
-            aria-label="Options"
-            icon={<MenuIcon size="28" />}
-            variant="unstyled"
-            size="lg"
-          />
+  return (
+    <>
+      {/* 메뉴 버튼 */}
+      <Flex width="100%" justifyContent="flex-end">
+        <Button
+          onClick={onOpen}
+          variant="unstyled"
+          aria-label="Open Menu"
+        >
+          <MenuIcon size="28" />
+        </Button>
+      </Flex>
 
-          <MenuList  bg="#F9F7F7" color="white" >
-            {/* 첫 번째 MenuItem은 텍스트처럼 표시 */}
-            <MenuItem
-              isDisabled
-              fontSize="24px"
-              fontWeight="bold"
-              bg="#F9F7F7"
-              _hover={{ bg: "transparent" }}
-              _disabled={{ opacity: 1, cursor: "default", color: "#3887C7" }}
-              mb="1px"
-            >
+      {/* Drawer 컴포넌트 */}
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose} size="xs">
+        <DrawerOverlay />
+        <DrawerContent bg="#F9F7F7">
+          <DrawerCloseButton color="#595353" />
+          <DrawerHeader>
             <Flex align="center" gap="8px">
-            <Image
-            src={profile_example}
-            alt="profile"
-            width="30px"
-            height="30px"
-            borderRadius="full"
-            objectFit="contain"
-            />
-              {nickName} 님
+              <Image
+                src={profile_example}
+                alt="profile"
+                width="30px"
+                height="30px"
+                borderRadius="full"
+                objectFit="contain"
+              />
+              <Box fontWeight="extrabold" fontSize="24px" color="#3887C7">
+                {nickName} <span style={{ color: "#595353" }}>님</span>
+              </Box>
             </Flex>
-            </MenuItem>
+          </DrawerHeader>
 
-
+          <DrawerBody>
             <Link to="/setting">
-            <MenuItem
-              icon={<Settings size="20" color="#777C89" />}
-              bg="#F9F7F7"
-              _hover={{ bg: "#AFD5F4" }}
-              color = "#595353"
-              fontWeight={700}
-            >
-            계정 설정
-            </MenuItem>
+              <Button
+                leftIcon={<Settings size="20" color="#777C89" />}
+                bg="#F9F7F7"
+                _hover={{ bg: "#AFD5F4" }}
+                color="#595353"
+                fontWeight={700}
+                width="100%"
+                justifyContent="flex-start"
+                mb="4"
+              >
+                계정 설정
+              </Button>
             </Link>
 
             <Link to="/seetoppinglist">
-            <MenuItem
-              icon={<Dice5 size="20" color="#777C89" />}
-              bg="#F9F7F7"
-              _hover={{ bg: "#AFD5F4" }}
-              color = "#595353"
-              fontWeight={700}
-            >
-              빙어 뽑기
-            </MenuItem>
-
+              <Button
+                leftIcon={<Dice5 size="20" color="#777C89" />}
+                bg="#F9F7F7"
+                _hover={{ bg: "#AFD5F4" }}
+                color="#595353"
+                fontWeight={700}
+                width="100%"
+                justifyContent="flex-start"
+                mb="4"
+              >
+                빙어 뽑기
+              </Button>
             </Link>
 
             <Link to="/search">
-            <MenuItem
-              icon={<Search size="20" color="#777C89" />}
-              bg="#F9F7F7"
-              _hover={{ bg: "#AFD5F4" }}
-              color = "#595353"
-              fontWeight={700}
-            >
-              낚시터 찾기
-            </MenuItem>
+              <Button
+                leftIcon={<Search size="20" color="#777C89" />}
+                bg="#F9F7F7"
+                _hover={{ bg: "#AFD5F4" }}
+                color="#595353"
+                fontWeight={700}
+                width="100%"
+                justifyContent="flex-start"
+                mb="4"
+              >
+                낚시터 찾기
+              </Button>
             </Link>
 
             <Link to="/seetoppinglist">
-            <MenuItem
-              bg="#F9F7F7"
-              icon={<Fish size="20" color="#777C89" />}
-              _hover={{ bg: "#AFD5F4" }}
-              color = "#595353"
-              fontWeight={700}
-            >
-              내가 보낸 빙어
-            </MenuItem>
+              <Button
+                leftIcon={<Fish size="20" color="#777C89" />}
+                bg="#F9F7F7"
+                _hover={{ bg: "#AFD5F4" }}
+                color="#595353"
+                fontWeight={700}
+                width="100%"
+                justifyContent="flex-start"
+                mb="4"
+              >
+                내가 보낸 빙어
+              </Button>
             </Link>
 
-            {/* 구분선 추가 */}
+            {/* 구분선 */}
             <Box
               as="hr"
               borderColor="gray.700"
               borderWidth="1px"
-              my={2} /* 위아래 여백 */
+              my={4}
             />
-            <MenuItem
+
+            <Button
+              leftIcon={<LogOut size="20" color="#777C89" />}
               bg="#F9F7F7"
-              icon={<LogOut size="20" color="#777C89" />}
               _hover={{ bg: "#AFD5F4" }}
-              color = "#595353"
+              color="#595353"
               fontWeight={700}
-              
+              width="100%"
+              justifyContent="flex-start"
+              mb="4"
             >
               로그아웃
-            </MenuItem>
-            <MenuItem
+            </Button>
+
+            <Button
+              leftIcon={<Github size="20" color="#777C89" />}
               bg="#F9F7F7"
-              icon={<Github size="20" color="#777C89" />}
               _hover={{ bg: "#AFD5F4" }}
-              color = "#595353"
+              color="#595353"
               fontWeight={700}
-              
+              width="100%"
+              justifyContent="flex-start"
             >
               포피셔 소개
-            </MenuItem>
-
-          </MenuList>
-        </CustomedMenu>
-      </Flex>
-    );
-  };
-  
+            </Button>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};

--- a/src/components/home/Menu/index.tsx
+++ b/src/components/home/Menu/index.tsx
@@ -12,10 +12,18 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
-import { Settings, Github, Search, Fish, Dice5, LogOut, MenuIcon } from "lucide-react";
+import {
+  Settings,
+  Github,
+  Search,
+  Fish,
+  Dice5,
+  LogOut,
+  MenuIcon,
+} from "lucide-react";
 import profile_example from "../../../assets/profile_example.jpg";
 
-export const DrawerMenu = () => {
+export const Menu = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const nickName = "자고싶어핑";
 
@@ -23,11 +31,7 @@ export const DrawerMenu = () => {
     <>
       {/* 메뉴 버튼 */}
       <Flex width="100%" justifyContent="flex-end">
-        <Button
-          onClick={onOpen}
-          variant="unstyled"
-          aria-label="Open Menu"
-        >
+        <Button onClick={onOpen} variant="unstyled" aria-label="Open Menu">
           <MenuIcon size="28" />
         </Button>
       </Flex>
@@ -35,7 +39,11 @@ export const DrawerMenu = () => {
       {/* Drawer 컴포넌트 */}
       <Drawer isOpen={isOpen} placement="right" onClose={onClose} size="xs">
         <DrawerOverlay />
-        <DrawerContent bg="#F9F7F7">
+        <DrawerContent
+          bg="#F9F7F7"
+          maxWidth="250px" // 원하는 너비 설정
+          width="90%" // 반응형으로 설정 가능
+        >
           <DrawerCloseButton color="#595353" />
           <DrawerHeader>
             <Flex align="center" gap="8px">
@@ -63,7 +71,6 @@ export const DrawerMenu = () => {
                 fontWeight={700}
                 width="100%"
                 justifyContent="flex-start"
-                mb="4"
               >
                 계정 설정
               </Button>
@@ -78,7 +85,6 @@ export const DrawerMenu = () => {
                 fontWeight={700}
                 width="100%"
                 justifyContent="flex-start"
-                mb="4"
               >
                 빙어 뽑기
               </Button>
@@ -93,7 +99,6 @@ export const DrawerMenu = () => {
                 fontWeight={700}
                 width="100%"
                 justifyContent="flex-start"
-                mb="4"
               >
                 낚시터 찾기
               </Button>
@@ -108,19 +113,13 @@ export const DrawerMenu = () => {
                 fontWeight={700}
                 width="100%"
                 justifyContent="flex-start"
-                mb="4"
               >
                 내가 보낸 빙어
               </Button>
             </Link>
 
             {/* 구분선 */}
-            <Box
-              as="hr"
-              borderColor="gray.700"
-              borderWidth="1px"
-              my={4}
-            />
+            <Box as="hr" borderColor="gray.700" borderWidth="1px" my={4} />
 
             <Button
               leftIcon={<LogOut size="20" color="#777C89" />}
@@ -130,7 +129,6 @@ export const DrawerMenu = () => {
               fontWeight={700}
               width="100%"
               justifyContent="flex-start"
-              mb="4"
             >
               로그아웃
             </Button>

--- a/src/components/home/Menu/index.tsx
+++ b/src/components/home/Menu/index.tsx
@@ -34,17 +34,23 @@ export const Menu = () => {
         <Button onClick={onOpen} variant="unstyled" aria-label="Open Menu">
           <MenuIcon size="28" />
         </Button>
-      </Flex>
-
+        </Flex>
       {/* Drawer 컴포넌트 */}
-      <Drawer isOpen={isOpen} placement="right" onClose={onClose} size="xs">
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        size="xs"
+        trapFocus={false} // 트랩 비활성화
+        blockScrollOnMount={false} // 스크롤 블록 비활성화
+      >
         <DrawerOverlay />
         <DrawerContent
           bg="#F9F7F7"
-          maxWidth="250px" // 원하는 너비 설정
+          maxWidth="240px" // 원하는 너비 설정
           width="90%" // 반응형으로 설정 가능
         >
-          <DrawerCloseButton color="#595353" />
+          {/* <DrawerCloseButton color="#595353" /> */}
           <DrawerHeader>
             <Flex align="center" gap="8px">
               <Image
@@ -68,7 +74,7 @@ export const Menu = () => {
                 bg="#F9F7F7"
                 _hover={{ bg: "#AFD5F4" }}
                 color="#595353"
-                fontWeight={700}
+                      fontWeight="semibold"
                 width="100%"
                 justifyContent="flex-start"
               >
@@ -76,13 +82,13 @@ export const Menu = () => {
               </Button>
             </Link>
 
-            <Link to="/seetoppinglist">
+            <Link to="/fishdrawing">
               <Button
                 leftIcon={<Dice5 size="20" color="#777C89" />}
                 bg="#F9F7F7"
                 _hover={{ bg: "#AFD5F4" }}
                 color="#595353"
-                fontWeight={700}
+                fontWeight="semibold"
                 width="100%"
                 justifyContent="flex-start"
               >
@@ -96,7 +102,7 @@ export const Menu = () => {
                 bg="#F9F7F7"
                 _hover={{ bg: "#AFD5F4" }}
                 color="#595353"
-                fontWeight={700}
+                fontWeight="semibold"
                 width="100%"
                 justifyContent="flex-start"
               >
@@ -110,7 +116,7 @@ export const Menu = () => {
                 bg="#F9F7F7"
                 _hover={{ bg: "#AFD5F4" }}
                 color="#595353"
-                fontWeight={700}
+                fontWeight="semibold"
                 width="100%"
                 justifyContent="flex-start"
               >
@@ -119,14 +125,14 @@ export const Menu = () => {
             </Link>
 
             {/* 구분선 */}
-            <Box as="hr" borderColor="gray.700" borderWidth="1px" my={4} />
+            <Box as="hr" borderColor="#c0c0c0" borderWidth="1px" my={4} />
 
             <Button
               leftIcon={<LogOut size="20" color="#777C89" />}
               bg="#F9F7F7"
               _hover={{ bg: "#AFD5F4" }}
               color="#595353"
-              fontWeight={700}
+                fontWeight="semibold"
               width="100%"
               justifyContent="flex-start"
             >
@@ -138,7 +144,7 @@ export const Menu = () => {
               bg="#F9F7F7"
               _hover={{ bg: "#AFD5F4" }}
               color="#595353"
-              fontWeight={700}
+                fontWeight="semibold"
               width="100%"
               justifyContent="flex-start"
             >

--- a/src/pages/user/FishDrawingPage.tsx
+++ b/src/pages/user/FishDrawingPage.tsx
@@ -1,0 +1,70 @@
+import styled from "@emotion/styled";
+import { useState } from "react";
+import { SettingHeader } from "../../components/user/SettingHeader";
+import { WhiteInput } from "../../components/user/CustomedInput";
+import { Search } from "lucide-react";
+import { Flex, Text, Box, VStack, Image } from "@chakra-ui/react";
+import { users } from "../../__mocks__/search/data";
+
+export default function FishDrawingPage() {
+    const [otherNickname, setOtherNickname] = useState<string>("");
+
+    // 검색 결과 필터링
+    const filteredUsers = otherNickname.trim()
+        ? users.filter((user) =>
+              user.nickname.includes(otherNickname.trim())
+          )
+        : [];
+
+    return (
+        <Wrapper>
+            <h1>빙어뽑기맞음</h1>
+      
+            <Flex align="center" w="full" gap="8px" mt="20px">
+            
+                <WhiteInput
+                    icon={<Search size={24} color="#000000" />} 
+                    value={otherNickname}
+                    placeholder="낚시꾼 이름으로 찾기"
+                    handleChange={(e) => setOtherNickname(e.target.value)}>
+                </WhiteInput>
+            </Flex>
+            {/* 검색 결과 */}
+            <VStack align="center" mt="20px" w="full" spacing="8px">
+                {filteredUsers.length > 0 ? (
+                    filteredUsers.map((user) => (
+                        <Flex
+                            key={user.userId}
+                            p="12px"
+                            w="80%"
+                            borderWidth="1px"
+                            borderRadius="16px"
+                            borderColor="#E2E8F0"
+                            bg="#F7FAFC"
+                            align="center"
+                            cursor="pointer"
+                        >
+                            <Image src={user.profileImg} boxSize="40px" borderRadius="full" objectFit="contain" />
+                            <Text ml="8px" fontSize="16px" color="#03526B">
+                                {user.nickname}
+                            </Text>
+                        </Flex>
+                    ))
+                ) : (
+                    otherNickname.trim() && (
+                        <Text fontSize="14px" color="#777C89">
+                            검색 결과가 없습니다.
+                        </Text>
+                    )
+                )}
+            </VStack>
+        </Wrapper>
+    );
+}
+
+const Wrapper = styled.div`
+    width: calc(100% - 60px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -10,6 +10,7 @@ import SettingPage from "../pages/user/SettingPage";
 import SeeToppnigListPage from "../pages/user/SeeToppingListPage";
 import SearchPage from "../pages/user/SerachPage";
 import SetPasswordPage from "../pages/auth/SetPasswordPage";
+import FishDrawingPage from "../pages/user/FishDrawingPage";
 
 
 const router = createBrowserRouter([
@@ -52,6 +53,10 @@ const router = createBrowserRouter([
       {
         path: "setting",
         element: <SettingPage />,
+      },
+      {
+        path: "fishdrawing",
+        element: <FishDrawingPage />,
       },
       {
         path: "seetoppinglist",


### PR DESCRIPTION
# Done
resolve #4 

- Menu Drawer 구현
     피그마 디자인대로 구현하기 위해서 Menu -> Drawer로 바꿨으나 Chakra UI의 Drawer 컴포넌트가 **Portal** 을 통해 DOM의 최상위로 렌더링되어서 부모 컴포넌트나 flex의 영향을 받지 않음 
Drawer 컴포넌트에 Portal 동작을 비활성화하는 props를 추가해 보아도 안 돼서 웹 뷰에서 정중앙에 drawer가 펼쳐지는 것은 포기함 
-> 후에 시간이 남으면 하겠음
- 메뉴 하위 페이지들 router 설정 및 클릭 시 이동까지 구현