### PR TITLE
Fix#38 이메일 인증 관련 오류 해결

### DIFF
--- a/src/components/auth/CheckDuplicate/index.tsx
+++ b/src/components/auth/CheckDuplicate/index.tsx
@@ -1,14 +1,13 @@
 import { Flex, Box, Text, Input, useToast } from "@chakra-ui/react";
-import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { BlueRectangleButton } from "../../common/CustomedButton";
-import { getEmailCode } from "../../../api/auth/apis";
 import { EmailCodeSendRequest } from "../../../api/auth/types";
+import { useGetEmailCode } from "../../../hook/auth/useGetEmailCode";
 
 export const CheckDuplicate = () => {
   const [email, setEmail] = useState("");
   const toast = useToast();
-  const navigate = useNavigate();
+  const { getEmailCode, isSending } = useGetEmailCode();
 
   const handleChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
@@ -23,23 +22,10 @@ export const CheckDuplicate = () => {
         isClosable: true,
       });
       return;
-    }
-
-    localStorage.setItem("user_email", email);
-
-    const req: EmailCodeSendRequest = { email };
-
-    try {
-      await getEmailCode(req);
-      navigate("/emailcheck", { state: { from: "signup" } });
-    } catch (error) {
-      console.error("이메일 인증 요청 실패:", error);
-      toast({
-        title: "이메일 인증 요청에 실패했습니다.",
-        status: "error",
-        duration: 3000,
-        isClosable: true,
-      });
+    } else {
+      localStorage.setItem("user_email", email);
+      const req: EmailCodeSendRequest = { email };
+      getEmailCode(req);
     }
   };
 
@@ -66,7 +52,10 @@ export const CheckDuplicate = () => {
           _focus={{ backgroundColor: "#FFFEFE", boxShadow: "none" }}
         />
       </Flex>
-      <BlueRectangleButton onClick={handleEmailVerification}>
+      <BlueRectangleButton
+        onClick={handleEmailVerification}
+        isLoading={isSending}
+      >
         인증하기
       </BlueRectangleButton>
     </Box>

--- a/src/components/common/CustomedButton/index.tsx
+++ b/src/components/common/CustomedButton/index.tsx
@@ -4,11 +4,13 @@ import { COLOR } from "../../../styles/color";
 interface BlueRectangleButtonProps {
   children: ReactNode;
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  isLoading?: boolean;
 }
 
 export const BlueRectangleButton: React.FC<BlueRectangleButtonProps> = ({
   children,
   onClick,
+  isLoading,
 }) => {
   return (
     <Button
@@ -24,6 +26,7 @@ export const BlueRectangleButton: React.FC<BlueRectangleButtonProps> = ({
         bg: COLOR.DEEPBLUE, // hover 시 배경색
         color: "white", // hover 시 텍스트 색상 유지
       }}
+      isLoading={isLoading}
       // _active={{
       //   transform: "scale(0.98)", // 클릭할 때 버튼 살짝 줄어듦
       // }}

--- a/src/hook/auth/useGetEmailCode.ts
+++ b/src/hook/auth/useGetEmailCode.ts
@@ -1,0 +1,34 @@
+import { getEmailCode } from "../../api/auth/apis";
+import { EmailCodeSendRequest } from "../../api/auth/types";
+import { useMutation } from "@tanstack/react-query";
+import { useToast } from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+
+export const useGetEmailCode = () => {
+  const toast = useToast();
+  const navigate = useNavigate();
+
+  const getEmailCodeMutation = useMutation({
+    mutationFn: (req: EmailCodeSendRequest) => getEmailCode(req),
+    onSuccess: () => {
+      toast({
+        title: "인증 코드를 전송했습니다",
+        status: "success",
+        duration: 3000,
+      });
+      navigate("/emailcheck", { state: { from: "signup" } });
+    },
+    onError: () => {
+      toast({
+        title: "인증 코드 전송 실패",
+        status: "error",
+        duration: 3000,
+      });
+    },
+  });
+
+  return {
+    getEmailCode: getEmailCodeMutation.mutateAsync,
+    isSending: getEmailCodeMutation.isPending,
+  };
+};

--- a/src/hook/fishingspot/useGetFishingSpotId.ts
+++ b/src/hook/fishingspot/useGetFishingSpotId.ts
@@ -5,10 +5,17 @@ import {
 import { AxiosError } from "axios";
 import { useQuery } from "@tanstack/react-query";
 
-export const useGetFishingSpotId = () => {
+interface UseGetFishingSpotIdOptions {
+  enabled?: boolean;
+}
+
+export const useGetFishingSpotId = ({
+  enabled = true,
+}: UseGetFishingSpotIdOptions = {}) => {
   const { data, error } = useQuery<FishingSpotIdResponse, AxiosError>({
     queryKey: ["fishingSpotId"],
     queryFn: getFishingSpotId,
+    enabled,
   });
 
   return { data, error };

--- a/src/pages/auth/AfterSignUpPage.tsx
+++ b/src/pages/auth/AfterSignUpPage.tsx
@@ -15,13 +15,14 @@ export default function AfterSignUpPage() {
   const [username, setUsername] = useState("");
 
   const { changeNickname } = useChangeUserInfo();
+
+  // setPassword에서 온 경우 emailUser, 아니면 OAuth 사용자
+  const isEmailUser = localStorage.getItem("user_password") !== null;
+
   const { data } = useGetFishingSpotId({
     enabled: !isEmailUser, // isEmailUser면 훅 실행 X
   });
   const fishingSpotId = data?.fishingSpotId;
-
-  // setPassword에서 온 경우 emailUser, 아니면 OAuth 사용자
-  const isEmailUser = localStorage.getItem("user_password") !== null;
 
   const handleSubmit = async () => {
     if (!username) {

--- a/src/pages/auth/AfterSignUpPage.tsx
+++ b/src/pages/auth/AfterSignUpPage.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import { Box, useToast, Input, Text, Flex } from "@chakra-ui/react";
 import { BlueRectangleButton } from "../../components/common/CustomedButton";
 import { useNavigate } from "react-router-dom";
-import { useLocation } from "react-router-dom";
 import fisherman from "../../assets/pictures/fisherman_small.svg";
 import { signUpEmail } from "../../api/auth/apis";
 import { EmailSignUpRequest } from "../../api/auth/types";
@@ -11,9 +10,6 @@ import { useChangeUserInfo } from "../../hook/user/useChangeUserInfo";
 import { useGetFishingSpotId } from "../../hook/fishingspot/useGetFishingSpotId";
 
 export default function AfterSignUpPage() {
-  const location = useLocation();
-  const isOAuthUser = location.state?.oauthuser;
-
   const navigate = useNavigate();
   const toast = useToast();
   const [username, setUsername] = useState("");
@@ -21,6 +17,9 @@ export default function AfterSignUpPage() {
   const { changeNickname } = useChangeUserInfo();
   const { data } = useGetFishingSpotId();
   const fishingSpotId = data?.fishingSpotId;
+
+  // setPassword에서 온 경우 emailUser, 아니면 OAuth 사용자
+  const isEmailUser = localStorage.getItem("user_password") !== null;
 
   const handleSubmit = async () => {
     if (!username) {
@@ -33,7 +32,7 @@ export default function AfterSignUpPage() {
       return;
     }
 
-    if (isOAuthUser) {
+    if (!isEmailUser) {
       try {
         await changeNickname(username);
         toast({
@@ -43,10 +42,11 @@ export default function AfterSignUpPage() {
           duration: 3000,
           isClosable: true,
         });
-        const redirectUrl = localStorage.getItem("redirectUrl");
-        if (redirectUrl) {
-          localStorage.removeItem("redirectUrl"); // 저장된 링크 삭제
-          navigate(redirectUrl); // 저장된 링크로 리디렉션
+        const currentFishingSpotId = localStorage.getItem(
+          "currentFishingSpotId"
+        );
+        if (currentFishingSpotId) {
+          navigate(`/${currentFishingSpotId}`);
         } else {
           navigate(`/${fishingSpotId}`);
         }
@@ -61,7 +61,6 @@ export default function AfterSignUpPage() {
         });
       }
     } else {
-      // 일반 회원가입 사용자인 경우 기존 로직 실행
       const email = localStorage.getItem("user_email");
       const password = localStorage.getItem("user_password");
 
@@ -91,6 +90,8 @@ export default function AfterSignUpPage() {
           isClosable: true,
         });
         navigate("/login");
+        localStorage.removeItem("user_email");
+        localStorage.removeItem("user_password");
       } catch (error) {
         console.error("회원가입 실패:", error);
         toast({

--- a/src/pages/auth/AfterSignUpPage.tsx
+++ b/src/pages/auth/AfterSignUpPage.tsx
@@ -15,7 +15,9 @@ export default function AfterSignUpPage() {
   const [username, setUsername] = useState("");
 
   const { changeNickname } = useChangeUserInfo();
-  const { data } = useGetFishingSpotId();
+  const { data } = useGetFishingSpotId({
+    enabled: !isEmailUser, // isEmailUser면 훅 실행 X
+  });
   const fishingSpotId = data?.fishingSpotId;
 
   // setPassword에서 온 경우 emailUser, 아니면 OAuth 사용자

--- a/src/pages/auth/EmailCheckPage.tsx
+++ b/src/pages/auth/EmailCheckPage.tsx
@@ -5,7 +5,7 @@ import { WhiteHeader } from "../../components/common/Header";
 import { CodeCheck } from "../../components/auth/CodeCheck";
 
 export default function EmailCheckPage() {
-  const email = localStorage.getItem("saved_email");
+  const email = localStorage.getItem("user_email");
   const navigate = useNavigate();
   const from = useLocation().state?.from || "unknown"; // 기본값 설정
   const goBack = () => {

--- a/src/pages/auth/EmailCheckPage.tsx
+++ b/src/pages/auth/EmailCheckPage.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Text } from "@chakra-ui/react";
+import { Text, Box } from "@chakra-ui/react";
 import { WhiteHeader } from "../../components/common/Header";
 import { CodeCheck } from "../../components/auth/CodeCheck";
 
@@ -35,6 +35,19 @@ export default function EmailCheckPage() {
         letterSpacing={"-0.5px"}
       >
         <span style={{ fontWeight: "bold" }}>{email}</span>로 코드를 보냈습니다.
+      </Text>
+
+      <Text
+        color="#13353B"
+        mt="24px"
+        fontWeight="bold"
+        letterSpacing={"-0.5px"}
+        fontSize="14px"
+        textAlign="center"
+      >
+        간혹 인증 메일이 스팸함으로 분류될 수 있어요.
+        <br />
+        메일이 보이지 않는다면, 스팸 메일함도 꼭 확인해 주세요!
       </Text>
       <CodeCheck />
     </Wrapper>


### PR DESCRIPTION
- resolve #38 

# Done

- 이메일 인증 요청 후 pending 상태 처리 
    - 버튼에 spinner 적용
- localstorage에서 받아오는 이메일 key 명 수정 
    - saved _email -> user_email
- 스팸 메일함 확인 권고 멘트 추가
- 일반 회원가입 시 비밀번호 설정 페이지 후 닉네임 페이지로 navigate 되지 않는 현상 해결(health-check, mine 403)
    - AfterSignUpPage에서 email user, oauth user 처리 제대로 분기