### PR TITLE
Fix#44 FishingSpot 및 퀴즈 조회 버그 수정

### DIFF
--- a/src/api/fishingspot/types.ts
+++ b/src/api/fishingspot/types.ts
@@ -1,10 +1,8 @@
 export interface SmeltsPostRequestBody {
   smeltTypeId: number;
-  title: string;
   content: string;
   senderName: string;
   quiz?: {
-    title: string;
     content: string;
     type: string;
     questions: string[];

--- a/src/components/chef/MakeQuizChoiceSection.tsx
+++ b/src/components/chef/MakeQuizChoiceSection.tsx
@@ -18,8 +18,7 @@ export const MakeQuizChoiceSection = ({ onPrev }: { onPrev: () => void }) => {
   const [selectQuizType, setSelectQuizType] = useState<string | null>(null); // OX 또는 객관식 유형 관리
   const maxQuestionLength = 30;
 
-  const { setQuiz, setQuizTitle, setQuizContent, setQuizType } =
-    useSmeltStore();
+  const { setQuiz, setQuizContent, setQuizType } = useSmeltStore();
   const handleQuizTypeSelection = (clickType: "OX" | "MULTIPLE") => {
     if (selectQuizType === clickType) {
       setSelectQuizType(null);
@@ -32,7 +31,6 @@ export const MakeQuizChoiceSection = ({ onPrev }: { onPrev: () => void }) => {
 
   useEffect(() => {
     if (selectQuizType) {
-      setQuizTitle(question);
       setQuizContent(question);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/chef/WriteLetterSection.tsx
+++ b/src/components/chef/WriteLetterSection.tsx
@@ -11,8 +11,7 @@ export const WriteLetterSection = ({
   onNext: () => void;
 }) => {
   const navigate = useNavigate();
-  const { senderName, setSenderName, setTitle, content, setContent } =
-    useSmeltStore();
+  const { senderName, setSenderName, content, setContent } = useSmeltStore();
 
   const maxChefNameLength = 8;
   const maxToppingContentLength = 300;
@@ -25,7 +24,6 @@ export const WriteLetterSection = ({
   const handleChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value.slice(0, maxToppingContentLength);
     setContent(value);
-    setTitle(value);
   };
   return (
     <>

--- a/src/components/home/FloatToppings/FloatToppings.tsx
+++ b/src/components/home/FloatToppings/FloatToppings.tsx
@@ -74,6 +74,10 @@ const ToppingElement = ({ topping }: ToppingProps) => {
       return;
     } //chef면 클릭 막기
     localStorage.setItem("selectedToppingId", topping.id.toString());
+    localStorage.setItem(
+      "selectedToppingTypeId",
+      topping.smeltTypeId.toString()
+    );
 
     switch (topping.status) {
       case SmeltStatus.UNREAD:

--- a/src/components/home/FloatToppings/FloatToppings.tsx
+++ b/src/components/home/FloatToppings/FloatToppings.tsx
@@ -148,7 +148,7 @@ export const ToppingsPagination = () => {
         이전
       </IconButton>
       <Text>
-        {currentPage + 1} / {totalPages + 1}
+        {currentPage + 1} / {totalPages}
       </Text>
       <IconButton
         onClick={handleNextPage}

--- a/src/components/owner/OpenQuiz/index.tsx
+++ b/src/components/owner/OpenQuiz/index.tsx
@@ -8,23 +8,23 @@ import { ModalInsideWhiteContainer } from "../../home/modal/ModalCustomedElement
 
 import { useQueryQuiz } from "../../../hook/smelts/useQueryQuiz";
 import { useSmeltsImg } from "../../../hook/smelts/useSmeltsImg";
-import { useSmeltsDetail } from "../../../hook/smelts/useSmeltsDetail";
-import { useSolveQuiz } from "../../../hook/smelts/useSolveQuiz"; // 추가
+
+import { useSolveQuiz } from "../../../hook/smelts/useSolveQuiz";
 
 export const OpenQuiz = () => {
   const selectedToppingId = Number(localStorage.getItem("selectedToppingId"));
+  const selectedToppingTypeId = Number(
+    localStorage.getItem("selectedToppingTypeId")
+  );
   const { data } = useQueryQuiz(selectedToppingId);
   const { getImageUrl } = useSmeltsImg();
-  const { data: smeltsDetail } = useSmeltsDetail(selectedToppingId);
-  const { mutate: solveQuizMutate } = useSolveQuiz(selectedToppingId); // 추가
+
+  const { mutate: solveQuizMutate } = useSolveQuiz(selectedToppingId);
 
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null); // 선택한 답변
   const [correctAnswer, setCorrectAnswer] = useState<boolean | null>(null); // 정답 여부
 
-  const imgURL =
-    smeltsDetail?.smelt.status === "READ"
-      ? getImageUrl(smeltsDetail?.smelt.smeltTypeId ?? 1) || ""
-      : getImageUrl(smeltsDetail?.smelt.smeltTypeId ?? 1, true) || "";
+  const imgURL = getImageUrl(selectedToppingTypeId, true) ?? ""; // 아이스 이미지 URL 가져오기
 
   const { setModalState } = useModalStateStore();
   const { onClose } = useModalOpenStore();

--- a/src/components/owner/OpenQuiz/index.tsx
+++ b/src/components/owner/OpenQuiz/index.tsx
@@ -2,14 +2,27 @@ import { useState, useEffect } from "react";
 import { useModalStateStore, useModalOpenStore } from "../../../store/modal";
 import { useModalHeight } from "../../../hook/useModalHeight";
 import { Circle, X, XIcon } from "lucide-react";
-import { Flex, IconButton, Button, Text, Image } from "@chakra-ui/react";
-
+import {
+  Flex,
+  IconButton,
+  Button,
+  Text,
+  Image,
+  keyframes,
+} from "@chakra-ui/react";
 import { ModalInsideWhiteContainer } from "../../home/modal/ModalCustomedElement";
-
 import { useQueryQuiz } from "../../../hook/smelts/useQueryQuiz";
 import { useSmeltsImg } from "../../../hook/smelts/useSmeltsImg";
-
 import { useSolveQuiz } from "../../../hook/smelts/useSolveQuiz";
+
+// 흔들림 애니메이션
+const shake = keyframes`
+  0% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  50% { transform: translateX(5px); }
+  75% { transform: translateX(-5px); }
+  100% { transform: translateX(0); }
+`;
 
 export const OpenQuiz = () => {
   const selectedToppingId = Number(localStorage.getItem("selectedToppingId"));
@@ -21,14 +34,15 @@ export const OpenQuiz = () => {
 
   const { mutate: solveQuizMutate } = useSolveQuiz(selectedToppingId);
 
-  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null); // 선택한 답변
-  const [correctAnswer, setCorrectAnswer] = useState<boolean | null>(null); // 정답 여부
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+  const [correctAnswer, setCorrectAnswer] = useState<boolean | null>(null);
+  const [wrongAnswer, setWrongAnswer] = useState<string | null>(null); // 오답 상태
+  const [isShaking, setIsShaking] = useState(false); // 흔들림 상태
 
-  const imgURL = getImageUrl(selectedToppingTypeId, true) ?? ""; // 아이스 이미지 URL 가져오기
+  const imgURL = getImageUrl(selectedToppingTypeId, true) ?? "";
 
   const { setModalState } = useModalStateStore();
   const { onClose } = useModalOpenStore();
-
   const [modalHeight, setModalHeight] = useState("50%");
 
   useEffect(() => {
@@ -46,28 +60,38 @@ export const OpenQuiz = () => {
 
   const handleClose = () => onClose();
 
-  // 답변 선택 시 호출되는 함수
+  useEffect(() => {
+    if (wrongAnswer) {
+      setIsShaking(true);
+      const timer = setTimeout(() => {
+        setWrongAnswer(null);
+        setIsShaking(false);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [wrongAnswer]);
+
   const clickAnswer = (questionId: number) => {
-    if (selectedAnswer !== null) {
+    if (correctAnswer === true) {
       return;
-    } // 이미 답변을 선택한 경우 무시
+    }
 
     setSelectedAnswer(questionId.toString());
 
-    // 퀴즈 정답 제출
     solveQuizMutate(
       { questionId },
       {
         onSuccess: (response) => {
-          setCorrectAnswer(response.result); // 정답 여부 저장
+          setCorrectAnswer(response.result);
           if (response.result) {
-            setTimeout(() => {
-              setModalState("readmessage"); // 정답이면 모달 상태 변경
-            }, 1000); // 1초 후에 모달 상태 변경
+            setTimeout(() => setModalState("readmessage"), 1000);
+          } else {
+            setWrongAnswer(questionId.toString());
           }
         },
         onError: (error) => {
           console.error("퀴즈 제출 실패:", error);
+          setSelectedAnswer(null);
         },
       }
     );
@@ -78,9 +102,9 @@ export const OpenQuiz = () => {
       <Header onClose={handleClose} img={imgURL} />
       <Question title={data?.quiz.title ?? "퀴즈 조회 X"} />
       <Flex gap="20px" mt="20px" justify="center">
-        {data?.questions.map((option, index) => (
+        {data?.questions.map((option) => (
           <IconButton
-            key={index}
+            key={option.id}
             bg={option.content === "O" ? "#03526B" : "#BF2A2A"}
             borderRadius="30px"
             boxSize="140px"
@@ -94,14 +118,18 @@ export const OpenQuiz = () => {
             }
             _hover={{ bg: "blue.600" }}
             border={
-              selectedAnswer === option.content
-                ? correctAnswer === true
-                  ? "5px solid green"
-                  : correctAnswer === false
-                  ? "5px solid red"
-                  : "none"
+              correctAnswer === true && selectedAnswer === option.id.toString()
+                ? "5px solid green"
+                : wrongAnswer === option.id.toString()
+                ? "5px solid red"
                 : "none"
             }
+            animation={
+              wrongAnswer === option.id.toString() && isShaking
+                ? `${shake} 0.5s ease-in-out`
+                : "none"
+            }
+            isDisabled={correctAnswer === true}
             onClick={() => clickAnswer(option.id)}
           />
         ))}
@@ -114,24 +142,28 @@ export const OpenQuiz = () => {
       <Header onClose={handleClose} img={imgURL} />
       <Question title={data?.quiz.title ?? "퀴즈 조회 X"} />
       <Flex direction="column" gap="10px" mt="20px" width="100%" align="center">
-        {data?.questions.map((option, index) => (
+        {data?.questions.map((option) => (
           <Button
-            key={index}
+            key={option.id}
             width="calc(100% - 40px)"
             borderRadius="12px"
             onClick={() => clickAnswer(option.id)}
             border={
-              selectedAnswer === option.id.toString()
-                ? correctAnswer === true
-                  ? "5px solid green"
-                  : correctAnswer === false
-                  ? "5px solid red"
-                  : "none"
+              correctAnswer === true && selectedAnswer === option.id.toString()
+                ? "5px solid green"
+                : wrongAnswer === option.id.toString()
+                ? "5px solid red"
+                : "none"
+            }
+            animation={
+              wrongAnswer === option.id.toString() && isShaking
+                ? `${shake} 0.5s ease-in-out`
                 : "none"
             }
             bg="#03526B"
             color="white"
             _hover={{ bg: "blue.600" }}
+            isDisabled={correctAnswer === true}
           >
             {option.content}
           </Button>
@@ -145,8 +177,8 @@ export const OpenQuiz = () => {
 
 const Header = ({ onClose, img }: { onClose: () => void; img: string }) => (
   <Flex w="full" justify="center" align="center" p="10px">
-    <Image src={img} boxSize="80px" position="absolute" top="-40px" />
-    <Text fontSize="24px" fontWeight="bold" color="#03526B">
+    <Image src={img} boxSize="80px" position="absolute" top="-50px" />
+    <Text fontSize="24px" fontWeight="bold" color="#03526B" mt="30px">
       퀴즈
     </Text>
     <IconButton

--- a/src/components/owner/ReadMessage/index.tsx
+++ b/src/components/owner/ReadMessage/index.tsx
@@ -12,13 +12,13 @@ import { useReply } from "../../../hook/smelts/useReply";
 
 export const ReadMessage = () => {
   const selectedToppingId = Number(localStorage.getItem("selectedToppingId"));
+  const selectedToppingTypeId = Number(
+    localStorage.getItem("selectedToppingTypeId")
+  );
   const { data } = useSmeltsDetail(selectedToppingId);
   const { getImageUrl } = useSmeltsImg();
 
-  const imgURL =
-    data?.smelt.status === "READ"
-      ? getImageUrl(data?.smelt.smeltTypeId ?? 1)
-      : getImageUrl(data?.smelt.smeltTypeId ?? 1, true);
+  const imgURL = getImageUrl(selectedToppingTypeId, false) ?? ""; //얼음 풀린 이미지
   const { setModalState } = useModalStateStore();
   const { onClose } = useModalOpenStore();
 

--- a/src/hook/fishingspot/useSendSmelts.ts
+++ b/src/hook/fishingspot/useSendSmelts.ts
@@ -4,15 +4,13 @@ import { useSmeltStore } from "../../hook/fishingspot/useSmeltStore"; // zustand
 
 export function useSendSmelts(fishingSpotId: number) {
   const queryClient = useQueryClient();
-  const { smeltTypeId, title, content, senderName, quiz, resetForm } =
-    useSmeltStore();
+  const { smeltTypeId, content, senderName, quiz, resetForm } = useSmeltStore();
 
   return useMutation({
     mutationFn: () =>
       sendSmelts(fishingSpotId, {
         //zustand
         smeltTypeId,
-        title,
         content,
         senderName,
         quiz,

--- a/src/hook/fishingspot/useSmeltStore.ts
+++ b/src/hook/fishingspot/useSmeltStore.ts
@@ -2,7 +2,6 @@ import { create } from "zustand";
 import { SmeltsPostRequestBody } from "../../api/fishingspot/types";
 
 interface QuizState {
-  title: string;
   content: string;
   type: "OX" | "MULTIPLE";
   questions: string[];
@@ -11,20 +10,17 @@ interface QuizState {
 
 interface SmeltState extends Omit<SmeltsPostRequestBody, "quiz"> {
   smeltTypeId: number;
-  title: string;
   content: string;
   senderName: string;
-
   quiz: QuizState | null;
 
   setSmeltTypeId: (smeltTypeId: number) => void;
-  setTitle: (title: string) => void;
+
   setContent: (content: string) => void;
   setSenderName: (senderName: string) => void;
 
   setQuiz: (quiz: QuizState | null) => void;
 
-  setQuizTitle: (title: string) => void;
   setQuizContent: (content: string) => void;
   setQuizType: (type: "OX" | "MULTIPLE") => void;
   setQuizQuestions: (questions: string[]) => void;
@@ -43,24 +39,11 @@ export const useSmeltStore = create<SmeltState>((set, get) => ({
   quiz: null,
 
   setSmeltTypeId: (smeltTypeId) => set({ smeltTypeId }),
-  setTitle: (title) => set({ title }),
+
   setContent: (content) => set({ content }),
   setSenderName: (senderName) => set({ senderName }),
 
   setQuiz: (quiz) => set({ quiz }),
-
-  setQuizTitle: (title) =>
-    set((state) => ({
-      quiz: state.quiz
-        ? { ...state.quiz, title }
-        : {
-            title,
-            content: "",
-            type: "OX",
-            questions: [],
-            answerIndex: 0,
-          },
-    })),
 
   setQuizContent: (content) =>
     set((state) => ({
@@ -117,7 +100,7 @@ export const useSmeltStore = create<SmeltState>((set, get) => ({
   resetForm: () =>
     set({
       smeltTypeId: 0,
-      title: "",
+
       content: "",
       senderName: "",
       quiz: null,
@@ -125,6 +108,6 @@ export const useSmeltStore = create<SmeltState>((set, get) => ({
 
   hasValidQuiz: () => {
     const { quiz } = get();
-    return !!quiz && !!quiz.title && !!quiz.content;
+    return !!quiz && !!quiz.content;
   },
 }));


### PR DESCRIPTION
- resolve #44 

# Done

### FishingSpot
- 페이지네이션 버튼 total page 숫자 맞게 뜨도록 수정

### 퀴즈
- 퀴즈 풀기 전엔 빙어 상세 조회 api 요청하지 않도록 수정
- 퀴즈 조회 모달에서 퀴즈 제목이랑 smelt img 간격 조절
- 퀴즈 풀 때 오답일 때 border 이펙트 떴다 사라지도록 및 오답 시에도 다른 선지들도 재선택할 수 있도록 수정
- 퀴즈 푼 상태일 때(편지 조회) detail 조회 훅 말고 저장한 typeId로 unIcedImg 조회하도록 수정

### 기타
- 편지 및 퀴즈 title field 삭제에 따른 type, request 수정
